### PR TITLE
[meta] fix build errors and warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ include_directories(${SFML_INCLUDE_DIR} ${OPENGL_INCLUDE_DIRS} ${GLEW_INCLUDE_DI
 add_executable(Fly ${SOURCES})
 target_link_libraries(Fly ${SFML_LIBRARIES} ${SFML_DEPENDENCIES} ${OPENGL_LIBRARIES} ${GLEW_LIBRARIES})
 
-set_property(TARGET Fly PROPERTY CXX_STANDARD 14)
+set_property(TARGET Fly PROPERTY CXX_STANDARD 17)
 set_property(TARGET Fly PROPERTY CXX_STANDARD_REQUIRED ON)
 
 target_link_libraries(Fly)

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -16,21 +16,20 @@ void Controller::takeInput(float dt)
 {
     // some shorthands..
     using Key       = sf::Keyboard;
-    auto  isPressed = sf::Keyboard::isKeyPressed;
 
-    if (isPressed(Key::W) || isPressed(Key::Up))
+    if (sf::Keyboard::isKeyPressed(Key::W) || sf::Keyboard::isKeyPressed(Key::Up))
         m_callbacks[ElevatorDown]();
-    if (isPressed(Key::S) || isPressed(Key::Down))
+    if (sf::Keyboard::isKeyPressed(Key::S) || sf::Keyboard::isKeyPressed(Key::Down))
         m_callbacks[ElevatorUp]();
 
-    if (isPressed(Key::A) || isPressed(Key::Left))
+    if (sf::Keyboard::isKeyPressed(Key::A) || sf::Keyboard::isKeyPressed(Key::Left))
         m_callbacks[RollLeft]();
-    if (isPressed(Key::D) || isPressed(Key::Right))
+    if (sf::Keyboard::isKeyPressed(Key::D) || sf::Keyboard::isKeyPressed(Key::Right))
         m_callbacks[RollRight]();
 
-    if (isPressed(Key::Space))
+    if (sf::Keyboard::isKeyPressed(Key::Space))
         m_callbacks[ThrustUp]();
-    if (isPressed(Key::LShift))
+    if (sf::Keyboard::isKeyPressed(Key::LShift))
         m_callbacks[ThrustDown]();
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include <memory>
 #include <chrono>
 #include <SFML/Window.hpp>
 #include <GL/glew.h>


### PR DESCRIPTION
the errors in question:
```
note: 'std::unique_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
   18 | #include "Debug/Box.h"
  +++ |+#include <memory>

error: unable to deduce 'auto' from 'sf::Keyboard::isKeyPressed'
   19 |     auto  isPressed = sf::Keyboard::isKeyPressed;
```